### PR TITLE
Add support for mapping user uid/gid

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -5,10 +5,13 @@ services:
     container_name: salt_master
     image: cdalvaro/saltstack-master:2018.3.2
     volumes:
-      - "./srv/:/srv/:ro"
+      - "./srv/:/home/salt/data/srv"
     ports:
       - "4505:4505/tcp"
       - "4506:4506/tcp"
     environment:
       - DEBUG=false
+      - USERMAP_UID=501
+      - USERMAP_GID=20
+
       - SALT_LOG_LEVEL=info

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -8,16 +8,12 @@ source "${SALT_RUNTIME_DIR}/functions.sh"
 case ${1} in
   app:start|app:init|app:gen-signed-keys)
 
-    configure_salt_master
+    initialize_system
 
     case ${1} in
       app:start)
-        setup_keys
         echo "Starting salt-master..."
         exec salt-master
-        ;;
-      app:init)
-        setup_keys
         ;;
       app:gen-signed-keys)
         shift 1
@@ -28,7 +24,6 @@ case ${1} in
   app:help)
     echo "Available options:"
     echo "  app:start                         - Start salt-master service. (default)"
-    echo "  app:init                          - Setup salt-master without launching the service."
     echo "  app:gen-signed-keys <key_name>    - Create a master_sign key pair and its signature inside ${SALT_KEYS_DIR}/generated/"
     echo "  app:help                          - Displays this help."
     echo "  [command]                         - Execute the specified command, eg. bash."


### PR DESCRIPTION
`salt-master` is now runned as `salt` user.

This user is mapped to the host user `uid` and `gid` via `USERMAP_UID` and `USERMAP_GID` variables.

```sh
docker run --name salt_stack -it --rm \
    --env "USERMAP_UID=$(id -u)" --env "USERMAP_GID=$(id -g)" \
    --volume $(pwd)/srv/:/home/salt/data/srv/ \
    cdalvaro/saltstack-master:2018.3.2
```

`config`, `keys` and `srv` directories are now located inside `/home/salt/data` path.