### PR TITLE
Add crond to supervisor

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,8 @@ Please refer to the SaltStack [Release Notes](https://docs.saltstack.com/en/deve
 - Add support for setting timezone
 - Add logrotate support
 - Add supervisor support
+- Add cron support
+- Add Docker Labels from label-schema.org
 - Addressed a bug that caused the container to crash when `/home/salt/data/keys/minions` was not present
 
 **2018.3.2**

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,8 +1,7 @@
 FROM ubuntu:xenial-20181113
 
-LABEL maintainer="carlos.alvaro@citelan.es"
-LABEL description="SaltStack master"
-LABEL version="2018.3.3"
+ARG BUILD_DATE
+ARG VCS_REF
 
 # https://github.com/saltstack/salt/releases
 ENV SALT_VERSION="2018.3.3" \
@@ -75,7 +74,20 @@ RUN rm -rf ${SALT_BUILD_DIR}/*
 # Entrypoint
 COPY entrypoint.sh /sbin/entrypoint.sh
 RUN chmod +x /sbin/entrypoint.sh
-WORKDIR ${SALT_HOME}
 
+LABEL \
+    maintainer="github@cdalvaro.io" \
+    org.label-schema.vendor=cdalvaro \
+    org.label-schema.name="SaltStack Master" \
+    org.label-schema.version=${SALT_VERSION} \
+    org.label-schema.description="Dockerized SaltStack Master" \
+    org.label-schema.url="https://github.com/cdalvaro/saltstack-master" \
+    org.label-schema.vcs-url="https://github.com/cdalvaro/saltstack-master.git" \
+    org.label-schema.vcs-ref=${VCS_REF} \
+    org.label-schema.build-date=${BUILD_DATE} \
+    org.label-schema.docker.schema-version="1.0" \
+    com.cdalvaro.saltstack-master.license=MIT
+
+WORKDIR ${SALT_HOME}
 ENTRYPOINT [ "/sbin/entrypoint.sh" ]
 CMD [ "app:start" ]

--- a/assets/build/install.sh
+++ b/assets/build/install.sh
@@ -84,17 +84,30 @@ sed -i "s|^su root syslog$|su root root|" /etc/logrotate.conf
 # Configure supervisor
 echo "Configuring supervisor ..."
 
-# configure supervisord to start unicorn
+# configure supervisord to start salt-master
 cat > /etc/supervisor/conf.d/salt-master.conf <<EOF
 [program:salt-master]
 priority=5
 directory=${SALT_HOME}
 environment=HOME=${SALT_HOME}
-command=salt-master
+command=/usr/bin/salt-master
 user=${SALT_USER}
 autostart=true
 autorestart=true
 stopsignal=QUIT
+stdout_logfile=${SALT_LOGS_DIR}/supervisor/%(program_name)s.log
+stderr_logfile=${SALT_LOGS_DIR}/supervisor/%(program_name)s.log
+EOF
+
+# configure supervisord to start crond
+cat > /etc/supervisor/conf.d/cron.conf <<EOF
+[program:cron]
+priority=20
+directory=/tmp
+command=/usr/sbin/cron -f
+user=root
+autostart=true
+autorestart=true
 stdout_logfile=${SALT_LOGS_DIR}/supervisor/%(program_name)s.log
 stderr_logfile=${SALT_LOGS_DIR}/supervisor/%(program_name)s.log
 EOF

--- a/hooks/build
+++ b/hooks/build
@@ -1,0 +1,9 @@
+#!/bin/bash
+
+# Docker Daemon Build Hook
+# $IMAGE_NAME var is injected into the build so the tag is correct.
+
+docker build \
+		--build-arg=BUILD_DATE="$(date +"%Y-%m-%d %H:%M:%S%:z")" \
+		--build-arg=VCS_REF="$(git rev-parse --short HEAD)" \
+		-t ${IMAGE_NAME} .


### PR DESCRIPTION
`crond` has been added to the supervisor

Additionally, Docker labels have been changed to accomplish the [label-schema.org](http://label-schema.org/rc1/) standard.