### PR TITLE
Bugfix: logrotate was not selecting salt logs

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,0 +1,64 @@
+version: 2
+jobs:
+  build:
+    docker:
+      - image: circleci/golang:1-stretch-browsers-legacy
+        environment:
+          IMAGE_NAME: "cdalvaro/saltstack-master"
+
+    steps:
+      - checkout
+
+      - setup_remote_docker:
+          version: 18.03.1-ce
+
+      - run:
+          name: Docker info
+          command: |
+            docker version
+            docker info
+      - restore_cache:
+          keys:
+            - cache-v2-{{ .Branch }}
+          paths:
+            - /tmp/cache/layers.tar
+
+      - run:
+          name: Loading docker cache
+          command: |
+            if [[ -f /tmp/cache/layers.tar ]]; then
+              echo "Loading cache ..."
+              docker load -i /tmp/cache/layers.tar
+              docker image ls
+            else
+              echo "Couldn't find any caches"
+            fi
+      - run:
+          name: Build docker image
+          command: |
+            docker build \
+              --pull \
+              --cache-from=${IMAGE_NAME} \
+              --build-arg BUILD_DATE="$(date +"%Y-%m-%d %H:%M:%S%:z")" \
+              --build-arg VCS_REF=$(git rev-parse --short HEAD) \
+              -t ${IMAGE_NAME}:$(cat VERSION) .
+      - run:
+          name: Launching container for testing
+          command: |
+            docker run --rm --detach --name saltstack-master ${IMAGE_NAME}:$(cat VERSION)
+            sleep 120
+      - run:
+          name: Generate docker build image cache
+          command: |
+            mkdir -p /tmp/cache/
+            docker save -o /tmp/cache/layers.tar ${IMAGE_NAME}
+      - save_cache:
+          key: cache-v2-{{ .Branch }}
+          paths:
+            - /tmp/cache/layers.tar
+
+workflows:
+  version: 2
+  build:
+    jobs:
+      - build

--- a/assets/runtime/functions.sh
+++ b/assets/runtime/functions.sh
@@ -105,7 +105,7 @@ function setup_salt_keys()
     salt-key --gen-signature --auto-create --pub ${SALT_KEYS_DIR}/master.pub --signature-path ${SALT_KEYS_DIR}
   fi
 
-  for pub_key in $(find ${SALT_KEYS_DIR} -type f -maxdepth 1); do
+  for pub_key in $(find ${SALT_KEYS_DIR} -maxdepth 1 -type f); do
     if [[ ${pub_key} =~ .*\.pem$ ]]; then
       chmod 400 ${pub_key}
     else
@@ -113,7 +113,7 @@ function setup_salt_keys()
     fi
   done
 
-  find ${SALT_KEYS_DIR}/minions* -type f -maxdepth 1 -exec chmod 644 {} \;
+  find ${SALT_KEYS_DIR}/minions* -maxdepth 1 -type f -exec chmod 644 {} \;
   find ${SALT_HOME} -path ${SALT_KEYS_DIR}/\* -prune -o -print0 | xargs -0 chown -h ${SALT_USER}:
 }
 

--- a/assets/runtime/functions.sh
+++ b/assets/runtime/functions.sh
@@ -202,9 +202,7 @@ function configure_logrotate()
 {
   echo "Configuring logrotate ..."
 
-  if [[ -f /etc/logrotate.d/salt-common ]]; then
-    rm /etc/logrotate.d/salt-common
-  fi
+  rm -f /etc/logrotate.d/salt-common
 
   # configure supervisord log rotation
   cat > /etc/logrotate.d/supervisord <<EOF
@@ -219,16 +217,30 @@ ${SALT_LOGS_DIR}/supervisor/*.log {
 }
 EOF
 
-  # configure salt-master log rotation
+  # configure salt master, minion and key log rotation
   cat > /etc/logrotate.d/salt <<EOF
-${SALT_LOGS_DIR}/salt/* {
+${SALT_LOGS_DIR}/salt/master {
   ${SALT_LOG_ROTATE_FREQUENCY}
   missingok
   rotate ${SALT_LOG_ROTATE_RETENTION}
   compress
-  delaycompress
   notifempty
-  copytruncate
+}
+
+${SALT_LOGS_DIR}/salt/minion {
+  ${SALT_LOG_ROTATE_FREQUENCY}
+  missingok
+  rotate ${SALT_LOG_ROTATE_RETENTION}
+  compress
+  notifempty
+}
+
+${SALT_LOGS_DIR}/salt/key {
+  ${SALT_LOG_ROTATE_FREQUENCY}
+  missingok
+  rotate ${SALT_LOG_ROTATE_RETENTION}
+  compress
+  notifempty
 }
 EOF
 }


### PR DESCRIPTION
The '*' was not selecting the files inside `/home/salt/logs/salt`

Additionally, adds support for CircleCI continuous integration