### PR TITLE
Allow failures when caching images

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -36,6 +36,7 @@ jobs:
           docker buildx inspect --bootstrap
 
       - name: Cache latest images
+        continue-on-error: true
         run: |
           for PLATFORM in ${PLATFORMS}; do
             docker pull --platform "${PLATFORM}" "${IMAGE_NAME}:latest"


### PR DESCRIPTION
This prevents publishing to fail when a new architecture is added.